### PR TITLE
Replace "Pythonic" with "Python" in project descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Waxy
 
-A Pythonic wrapper around the Rust `taffy` UI layout library, built with PyO3/maturin.
+A Python wrapper around the Rust `taffy` UI layout library, built with PyO3/maturin.
 
 ## Key Files
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -19,7 +19,7 @@ The initial API will be a thin wrapper that closely mirrors taffy's Rust API:
 a `TaffyTree` object, node handles, and style structs. This keeps the binding layer
 straightforward and easy to maintain in sync with upstream taffy.
 
-A higher-level, more Pythonic/declarative API may be added later as a pure-Python
+A higher-level, more declarative API may be added later as a pure-Python
 layer on top of the bindings.
 
 ## Taffy Version

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,3 @@
 # Waxy
 
-A Pythonic wrapper around the Rust [taffy](https://github.com/DioxusLabs/taffy) UI layout library, built with [PyO3](https://pyo3.rs/) and [maturin](https://maturin.rs/).
+A Python wrapper around the Rust [taffy](https://github.com/DioxusLabs/taffy) UI layout library, built with [PyO3](https://pyo3.rs/) and [maturin](https://maturin.rs/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Waxy
-site_description: A Pythonic wrapper around the Rust taffy UI layout library
+site_description: A Python wrapper around the Rust taffy UI layout library
 repo_url: https://github.com/JoshKarpel/waxy
 repo_name: JoshKarpel/waxy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "waxy"
 version = "0.1.0"
-description = "A Pythonic wrapper around the Rust taffy UI layout library"
+description = "A Python wrapper around the Rust taffy UI layout library"
 requires-python = ">=3.13"
 license = "MIT"
 

--- a/python/waxy/__init__.py
+++ b/python/waxy/__init__.py
@@ -1,4 +1,4 @@
-"""Waxy: A Pythonic wrapper around the Rust taffy UI layout library."""
+"""Waxy: A Python wrapper around the Rust taffy UI layout library."""
 
 from waxy._waxy import (
     AlignContent,


### PR DESCRIPTION
This is a thin wrapper, not an opinionated Pythonic API.
The SPEC.md occurrence ("Pythonic/declarative") was simplified
to just "declarative" since that's the meaningful descriptor.

https://claude.ai/code/session_01Up3N3SqXVp6uNGqKhnyG7X